### PR TITLE
Fix: Remove redundant GITHUB_TOKEN from image-actions workflow

### DIFF
--- a/.github/workflows/compress.yml
+++ b/.github/workflows/compress.yml
@@ -27,5 +27,3 @@ jobs:
 
       - name: Compress Images
         uses: calibreapp/image-actions@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The calibreapp/image-actions action was receiving GITHUB_TOKEN in multiple ways, causing an @octokit/auth-action error. Remove the explicit env.GITHUB_TOKEN to let the action use the automatically available token from the job context.

Fixes job #72886473731

## Issue description

## Pull request checklist
- [ ] I've updated the localization
- [ ] I've updated the [CHANGELOG](https://github.com/mathnauleau/mathnauleau.github.io/blob/main/CHANGELOG.md)