### PR TITLE
Standardize design tokens and update styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ A list of all major changes. To update for each release.
 - Bricolage Grotesque font to pages
 
 ### Changed
+- Standardize design tokens and update styles
+- Made social icons bigger
+- Updated bootstrap year and styleguid
 - Updated color and typography tokens in `tokens.css`
 - Changed Secondary font
 - Changed en/fr icons
@@ -18,6 +21,9 @@ A list of all major changes. To update for each release.
 
 ### Fixed
 - Small accessibility improvement with better Aria label descriptions
+
+### Removed
+- Deleted emojicom
 
 ## 01.05.2026 - Version 2.04
 ### Changed

--- a/_Temp.html
+++ b/_Temp.html
@@ -327,7 +327,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/about.html
+++ b/about.html
@@ -219,7 +219,6 @@
     </section>
     <!-- End Toolbox -->
 
-    <div id="emojicom-widget-inline"></div>
   </main>
   <!-- End #main -->
 
@@ -278,10 +277,6 @@
   <script src="assets/vendor/glightbox/js/glightbox.min.js"></script>
   <script src="assets/vendor/isotope-layout/isotope.pkgd.min.js"></script>
   <script src="assets/vendor/swiper/swiper-bundle.min.js"></script>
-
-  <!-- Emojicom.io widget -->
-  <script>window.emojicom_widget = { campaign: "6lqSB2bUgBmHzDoiybww" };</script>
-  <script src="https://cdn.emojicom.io/embed/widget.js" async></script>
 
   <!-- Template Main JS File -->
   <script src="assets/js/main.js"></script>

--- a/about.html
+++ b/about.html
@@ -227,7 +227,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/ahcompact.html
+++ b/ahcompact.html
@@ -393,7 +393,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/carl.html
+++ b/carl.html
@@ -288,7 +288,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/custom.css
+++ b/custom.css
@@ -220,7 +220,7 @@ hr {
 /* Change color of dropdown links on hover */
 .dropdown-content button:hover {
   padding: 12px;
-  background-color: var(--color-brand-accent);
+  background-color: var(--color-neutral-300);
   font: var(--font-body-regular);
   color: white;
   text-align: justify;
@@ -947,8 +947,8 @@ section {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  width: 48px;
+  height: 48px;
   border-radius: 50%;
   background-color: var(--color-neutral-100);
   color: var(--color-brand-primary);
@@ -962,7 +962,7 @@ section {
 }
 
 .footer-social .social-links i {
-  font-size: 18px;
+  font-size: 24px;
 }
 
 /* Safari-specific fixes 

--- a/custom.css
+++ b/custom.css
@@ -1019,12 +1019,12 @@ section {
 
 .callout {
   padding: var(--space-medium);
-  background-color: var(--color-status-info);
+  background-color: var(--color-nav-default);
   border-radius: var(--border-radius-large);
 }
 
 .callout p {
-  margin: 8px 0 0 0;
+  margin: 8px 0 16px 0;
 }
 
 .callout strong {

--- a/custom.css
+++ b/custom.css
@@ -645,6 +645,7 @@ section {
 
 .btn-custom:hover {
   color: white;
+  background-color: var(--color-interactive-active);
 }
 
 .btn-custom2 {
@@ -752,12 +753,12 @@ section {
 
 .project-nav .prev-next {
   padding: var(--space-medium);
-  background-color: var(--color-neutral-100);
+  background-color: var(--color-nav-default);
   transition: all 0.4s;
 }
 
 .project-nav .prev-next:hover {
-  background-color: var(--color-interactive-hover);
+  background-color: var(--color-nav-hover);
 }
 
 .project-nav .prev-next span {

--- a/custom.css
+++ b/custom.css
@@ -1,15 +1,15 @@
 body {
-  font-family: var(--font-family-primary);
-  color: var(--color-primary);
-  background-color: var(--color-background);
+  font-family: var(--font-family-body);
+  color: var(--color-text-primary);
+  background-color: var(--color-background-light);
 }
 
 a {
-  color: var(--color-secondary);
+  color: var(--color-brand-accent);
 }
 
 a:hover {
-  color: var(--color-secondary-dark);
+  color: var(--color-brand-accent-dark);
 }
 
 /*--------------------------------------------------------------
@@ -17,27 +17,27 @@ a:hover {
 --------------------------------------------------------------*/
 
 h2 {
-  font-family: var(--font-family-primary);
+  font-family: var(--font-family-body);
 }
 
 h4 {
-  font-family: var(--font-family-primary);
+  font-family: var(--font-family-body);
 }
 
 h3 {
-  font-family: var(--font-family-primary);
+  font-family: var(--font-family-body);
 }
 
 /* Section heading-5 'CRAFT' */
 h5 {
-  font: var(--typography-overline);
+  font: var(--font-label);
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: var(--color-secondary);
+  color: var(--color-brand-accent);
 }
 
 hr {
-  color: var(--color-gray-4);
+  color: var(--color-neutral-300);
   opacity: 0.7;
 }
 
@@ -46,8 +46,8 @@ hr {
 }
 
 .header .logo span{ /* Fix needed */
-  font: var(--typography-bodyReg);
-  color: var(--color-primary);
+  font: var(--font-body-regular);
+  color: var(--color-brand-primary);
 }
 
 .logo img{
@@ -68,16 +68,16 @@ hr {
 }
 
 .hero h1 {
-  font: var(--typography-headline);
-  color: var(--color-primary-light);
-  background: -webkit-linear-gradient(290deg, var(--color-secondary) 0%, #11181c 50%, #11181c 100%);
+  font: var(--font-display-1);
+  color: var(--color-brand-primary-light);
+  background: -webkit-linear-gradient(290deg, var(--color-brand-accent) 0%, #11181c 50%, #11181c 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
 
 .hero h2 {
-  font: var(--typography-subhead);
-  color: var(--color-gray-8);
+  font: var(--font-body-regular-large);
+  color: var(--color-neutral-700);
   margin-block-start: var(--space-small);
 }
 
@@ -91,18 +91,18 @@ hr {
 
 .navbar a {
   padding: 16px;
-  font: var(--typography-bodyReg);
-  color: var(--color-primary);
+  font: var(--font-body-regular);
+  color: var(--color-brand-primary);
 }
 
 .navbar a:focus {
   padding: 16px;
-  font: var(--typography-bodyReg);
-  color: var(--color-secondary);
+  font: var(--font-body-regular);
+  color: var(--color-brand-accent);
 }
 
 .navbar a i, .navbar a:focus i{
-  font: var(--typography-heading-3);
+  font: var(--font-heading-2);
 }
 
 .overlay ul {
@@ -114,7 +114,7 @@ hr {
   left: var(--space-medium);
   padding: 16px;
   border-radius: 24px;
-  background-color: var(--color-background);
+  background-color: var(--color-background-light);
   overflow-y: auto;
   transition: 0.3s;
 }
@@ -123,7 +123,7 @@ hr {
   position: absolute;
   top: 48px;
   right: 48px;
-  color: var(--color-gray-8);
+  color: var(--color-neutral-700);
   font-size: 2.5em;
   transition: none;
 }
@@ -133,12 +133,12 @@ hr {
 }
 
 .overlay a:hover, .overlay .active, .overlay li:hover>a{
-  color: var(--color-secondary);
+  color: var(--color-brand-accent);
 }
 
 /* Header content styles */
 .header-content {
-  background-color: var(--color-gray-1);
+  background-color: var(--color-neutral-50);
   padding: 8px 16px 8px 16px;
   border-radius: var(--border-radius-large);
 }
@@ -182,7 +182,7 @@ hr {
 }
 
 .dropbtn:hover{
-  background-color: var(--color-gray-2);
+  background-color: var(--color-neutral-100);
 }
 
 /* The container <div> - needed to position the dropdown content */
@@ -201,11 +201,11 @@ hr {
 /* Links inside the dropdown */
 .dropdown-content button {
   color: black;
-  background-color: var(--color-gray-2);
+  background-color: var(--color-neutral-100);
   border-radius: 99px;
   padding: 12px;
   text-align: center;
-  font: var(--typography-bodyReg);
+  font: var(--font-body-regular);
   display: block;
   margin-top: 4px;
   width: 48px;
@@ -220,8 +220,8 @@ hr {
 /* Change color of dropdown links on hover */
 .dropdown-content button:hover {
   padding: 12px;
-  background-color: var(--color-secondary);
-  font: var(--typography-bodyReg);
+  background-color: var(--color-brand-accent);
+  font: var(--font-body-regular);
   color: white;
   text-align: justify;
   border-radius: 99px;
@@ -234,7 +234,7 @@ hr {
 
 /* Change the background color of the dropdown button when the dropdown content is shown */
 .dropdown:hover .dropbtn {
-  background-color: var(--color-gray-2);
+  background-color: var(--color-neutral-100);
 }
 
 .lang-mobile {
@@ -283,7 +283,7 @@ hr {
     font-size: 24px;
     font-weight: 300;
     padding: 16px;
-    color: var(--color-primary);
+    color: var(--color-brand-primary);
   }
 
   #portfolio .g-4,
@@ -399,8 +399,8 @@ hr {
 }
 
 .section-header h2, .portfolio-description h1 {
-  font: var(--typography-heading-1);
-  color: var(--color-primary);
+  font: var(--font-display-2);
+  color: var(--color-brand-primary);
   text-transform: none;
 }
 
@@ -487,7 +487,7 @@ section {
 
 .portfolio-item h4 {
   font-size: 18px;
-  color: var(--color-gray-7);
+  color: var(--color-neutral-600);
   margin-bottom: var(--space-small);
 }
 
@@ -517,7 +517,7 @@ section {
 
 .portfolio-title h4 {
   color: white;
-  font: var(--typography-subhead);
+  font: var(--font-body-regular-large);
   text-align: center;
 }
 
@@ -544,12 +544,12 @@ section {
 }
 
 .portfolio-hero h2, .portfolio-description h2 {
-  font: var(--typography-heading-2);
+  font: var(--font-heading-1);
   margin-bottom: var(--space-medium);
 }
 
 .portfolio-hero p, .portfolio-description p {
-  font: var(--typography-bodyReg);
+  font: var(--font-body-regular);
   margin-bottom: var(--space-large);
 }
 
@@ -576,7 +576,7 @@ section {
 .sub-section ul li, section ul li  {
   margin-bottom: 12px;
   padding-left: 8px;
-  font: var(--typography-bodyReg);
+  font: var(--font-body-regular);
 }
 
 .about .content {
@@ -590,7 +590,7 @@ section {
 }
 
 .portfolio-project-nav:hover {
-  background-color: var(--color-information);
+  background-color: var(--color-status-info);
 }
 
 .about {
@@ -598,14 +598,14 @@ section {
 }
 
 .about h2 {
-  font: var(--typography-heading-2);
-  color: var(--color-primary);
+  font: var(--font-heading-1);
+  color: var(--color-brand-primary);
   margin-bottom: var(--space-medium);
 }
 
 .about p {
-  font: var(--typography-bodyReg);
-  color: var(--color-gray-8);
+  font: var(--font-body-regular);
+  color: var(--color-neutral-700);
   margin: 0 0 var(--space-large) 0;
 }
 
@@ -623,12 +623,12 @@ section {
   border-radius: var(--border-radius-medium);
   transition: 0.5s;
   color: white;
-  background: var(--color-secondary);
+  background: var(--color-interactive-default);
   box-shadow: 0 5px 25px rgba(65, 84, 241, 0.3);
 }
 
 .btn-custom span {
-  font: var(--typography-button);
+  font: var(--font-label-button);
 }
 
 .btn-custom i,
@@ -648,10 +648,10 @@ section {
 }
 
 .btn-custom2 {
-  font: var(--typography-button);
+  font: var(--font-label-button);
   padding: 16px 24px;
   transition: 0.5s;
-  color: var(--color-secondary);
+  color: var(--color-brand-accent);
   background-color: transparent;
 }
 
@@ -669,32 +669,32 @@ section {
   height: 100%;
   overflow: hidden;
   padding: 28px;
-  background-color: var(--color-gray-2);
+  background-color: var(--color-neutral-100);
   border-radius: var(--border-radius-large);
 }
 
 .toolbox .info-box {
-  background-color: var(--color-gray-2);
+  background-color: var(--color-neutral-100);
 }
 
 .toolbox .info-box h3 {
-  color: var(--color-primary);
-  font: var(--typography-heading-3);
+  color: var(--color-brand-primary);
+  font: var(--font-heading-2);
   margin: 0 0 8px 0;
 }
 
 .toolbox .info-box p {
-  font: var(--typography-bodyReg);
-  color: var(--color-gray-8);
+  font: var(--font-body-regular);
+  color: var(--color-neutral-700);
 }
 
 .info-box h4 {
-  font: var(--typography-subtitle);
+  font: var(--font-heading-3);
 }
 
 .sub-section h3 {
-  font: var(--typography-subtitle);
-  color: var(--color-primary);
+  font: var(--font-heading-3);
+  color: var(--color-brand-primary);
 }
 
 /*--------------------------------------------------------------
@@ -752,12 +752,12 @@ section {
 
 .project-nav .prev-next {
   padding: var(--space-medium);
-  background-color: var(--color-nav-default);
+  background-color: var(--color-neutral-100);
   transition: all 0.4s;
 }
 
 .project-nav .prev-next:hover {
-  background-color: var(--color-nav-hover);
+  background-color: var(--color-interactive-hover);
 }
 
 .project-nav .prev-next span {
@@ -771,7 +771,7 @@ section {
 
 .direction {
   display: inline-flex;
-  font: var(--typography-bodyReg);
+  font: var(--font-body-regular);
   gap: 8px;
 }
 
@@ -786,13 +786,13 @@ section {
 }
 
 .title {
-  font: var(--typography-heading-2);
+  font: var(--font-heading-1);
 }
 
 .left,
 .right {
   text-align: left;
-  color: var(--color-primary);
+  color: var(--color-brand-primary);
   border-radius: var(--border-radius-large);
 }
 
@@ -805,12 +805,12 @@ section {
 }
 
 .portfolio-info strong {
-  font: var(--typography-bodyBold);
-  color: var(--color-primary);
+  font: var(--font-body-bold);
+  color: var(--color-brand-primary);
 }
 
 .portfolio-info p {
-  font: var(--typography-bodyReg);
+  font: var(--font-body-regular);
   margin: 0;
 }
 
@@ -840,8 +840,8 @@ section {
 }
 
 .portfolio-description h3 {
-  font: var(--typography-subhead);
-  color: var(--color-gray-8);
+  font: var(--font-body-regular-large);
+  color: var(--color-neutral-700);
 }
 
 .portfolio-section-highlight {
@@ -850,16 +850,16 @@ section {
   padding-top: var(--space-xxlarge);
   padding-bottom: var(--space-xxlarge);
   overflow: visible;
-  background-color: var(--color-gray-2);
+  background-color: var(--color-neutral-100);
 }
 
 .portfolio-section-highlight h2 {
-  font: var(--typography-heading-2);
+  font: var(--font-heading-1);
   margin-bottom: var(--space-xxlarge);
 }
 
 .portfolio-section-highlight p {
-  font: var(--typography-bodyReg);
+  font: var(--font-body-regular);
 }
 
 /*--------------------------------------------------------------
@@ -870,11 +870,11 @@ section {
   border-radius: 100px;
   right: 20px;
   bottom: 20px;
-  background-color: var(--color-primary);
+  background-color: var(--color-brand-primary);
 }
 
 .back-to-top:hover {
-  background-color: var(--color-secondary);
+  background-color: var(--color-brand-accent);
 }
 
 .collaboration {
@@ -888,12 +888,12 @@ section {
   border-radius: var(--border-radius-large);
 }
 .collaboration h2 {
-  font: var(--typography-heading-2);
+  font: var(--font-heading-1);
   text-align: left;
 }
 
 .collaboration p {
-  font: var(--typography-bodyReg);
+  font: var(--font-body-regular);
   text-align: left;
 }
 
@@ -919,7 +919,7 @@ section {
 }
 
 .footer .copyright p {
-  font: var(--typography-caption);
+  font: var(--font-caption);
   margin-bottom: 0;
 }
 
@@ -949,14 +949,14 @@ section {
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background-color: var(--color-gray-2);
-  color: var(--color-primary);
+  background-color: var(--color-neutral-100);
+  color: var(--color-brand-primary);
   text-decoration: none;
   transition: all 0.3s ease;
 }
 
 .footer-social .social-links:hover {
-  color: var(--color-secondary);
+  color: var(--color-brand-accent);
   transform: translateY(-2px);
 }
 
@@ -1008,7 +1008,7 @@ section {
 }
 
 #password::placeholder{
-  font-family: var(--font-family-primary);
+  font-family: var(--font-family-body);
   color: lightslategray;
 }
 
@@ -1018,7 +1018,7 @@ section {
 
 .callout {
   padding: var(--space-medium);
-  background-color: var(--color-information);
+  background-color: var(--color-status-info);
   border-radius: var(--border-radius-large);
 }
 
@@ -1027,7 +1027,7 @@ section {
 }
 
 .callout strong {
-  font: var(--typography-subtitle);
+  font: var(--font-heading-3);
 }
 
 /*--------------------------------------------------------------
@@ -1104,7 +1104,7 @@ section {
 }
 
 .background-hero-title {
-  font-family: var(--font-family-primary);
+  font-family: var(--font-family-body);
   font-size: 60px; /* Custom */
   font-weight: 800;
   color: #6ab7e43e;

--- a/custom.css
+++ b/custom.css
@@ -169,7 +169,7 @@ hr {
   border: none;
   width: 48px;
   height: 48px;
-  border-radius: 99px;
+  border-radius: var(--border-radius-circle);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -202,7 +202,7 @@ hr {
 .dropdown-content button {
   color: black;
   background-color: var(--color-neutral-100);
-  border-radius: 99px;
+  border-radius: var(--border-radius-circle);
   padding: 12px;
   text-align: center;
   font: var(--font-body-regular);
@@ -224,7 +224,7 @@ hr {
   font: var(--font-body-regular);
   color: white;
   text-align: justify;
-  border-radius: 99px;
+  border-radius: var(--border-radius-circle);
 }
 
 /* Show the dropdown menu on hover */

--- a/dailyui.html
+++ b/dailyui.html
@@ -240,7 +240,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/designsystem.html
+++ b/designsystem.html
@@ -163,7 +163,7 @@
     <!-- ======= Start Portfolio Development Section ======= -->
 
     <section class="sub-section container-xxl col-lg-9 about" style="margin-top: 0">
-      <div class="rounded-4 container-fluid bg-light">
+      <div class="rounded-4 container-fluid">
         <div class="row">
           <div class="col-3 align-self-center">
             <img src="assets/img/wip.png" alt="img" style="display: block; margin: auto; width: 160px">

--- a/designsystem.html
+++ b/designsystem.html
@@ -164,7 +164,7 @@
 
     <section class="sub-section container-xxl col-lg-9 about" style="margin-top: 0">
       <div class="rounded-4 container-fluid">
-        <div class="row">
+        <div class="row callout">
           <div class="col-3 align-self-center">
             <img src="assets/img/wip.png" alt="img" style="display: block; margin: auto; width: 160px">
           </div>
@@ -228,7 +228,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/island.html
+++ b/island.html
@@ -256,7 +256,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/kumiko.html
+++ b/kumiko.html
@@ -232,7 +232,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/private/5face4c93baff88a89a7fb13a3cebba9f4f93634/index.html
+++ b/private/5face4c93baff88a89a7fb13a3cebba9f4f93634/index.html
@@ -569,7 +569,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/rise.html
+++ b/rise.html
@@ -363,7 +363,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/sketching.html
+++ b/sketching.html
@@ -240,7 +240,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>

--- a/styleguide.html
+++ b/styleguide.html
@@ -19,7 +19,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap"
     rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,200..800&display=swap"
+  <link
+    href="https://fonts.googleapis.com/css2?family=Bricolage Grotesque+Grotesque:opsz,wght@12..96,200..800&display=swap"
     rel="stylesheet">
 
   <!-- Vendor CSS Files -->
@@ -163,67 +164,61 @@
       <table>
         <tbody>
           <tr>
-            <td>display-1 <br> 700 3.5em/1.2em</td>
+            <td>display-1 <br> 700 3.5em/1.2em "Bricolage Grotesque"</td>
             <td>
               <h1 style="font: var(--font-display-1)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>display-2 <br> 700 2.5em/1.3em</td>
+            <td>display-2 <br> 700 2.5em/1.3em "Bricolage Grotesque"</td>
             <td>
               <h1 style="font: var(--font-display-2)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>heading-1 <br> 700 2em/1.3em "Bricolage"</td>
+            <td>heading-1 <br> 700 2em/1.3em "Bricolage Grotesque"</td>
             <td>
               <h1 style="font: var(--font-heading-1)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>heading-2 <br> 700 1.5em/1.5em "Bricolage"</td>
+            <td>heading-2 <br> 700 1.5em/1.5em "Bricolage Grotesque"</td>
             <td>
               <h1 style="font: var(--font-heading-2)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>heading-3 <br> 700 1.25em/1.5em "Inter"</td>
+            <td>heading-3 <br> 700 1.25em/1.5em Bricolage Grotesque</td>
             <td>
               <h1 style="font: var(--font-heading-3)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>body-xlarge <br> 300 1.5em/1.5em "Inter"</td>
+            <td>body-regular-large <br> 300 1.5em/1.5em "Inter"</td>
             <td>
               <h1 style="font: var(--font-body-regular-large)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>body-large-strong <br> 700 1em/1.5em "Inter"</td>
+            <td>body-bold <br> 700 1em/1.5em "Inter"</td>
             <td>
               <h1 style="font: var(--font-body-bold)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>body-large <br> 300 1em/1.5em "Inter"</td>
+            <td>body-regular <br> 300 1em/1.5em "Inter"</td>
             <td>
               <h1 style="font: var(--font-body-regular)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>body-default-strong <br> 500 1em/1em "Inter"</td>
+            <td>label-button <br> 500 1em/1em "Inter"</td>
             <td>
               <h1 style="font: var(--font-label-button)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>body-default <br> 300 1em/1.5em "Inter"</td>
-            <td>
-              <h1 style="font: var(--font-body-regular)">Ipsum Dolor Sit Amet</h1>
-            </td>
-          </tr>
-          <tr>
-            <td>label <br> 700 1em/1em "Bricolage"</td>
+            <td>label <br> 700 1em/1em "Bricolage Grotesque"</td>
             <td>
               <h1 style="font: var(--font-label)">IPSUM DOLOR SIT AMET</h1>
             </td>
@@ -295,6 +290,18 @@
       </div>
     </div>
 
+    <h6 style="font: var(--font-heading-3)">Text colors</h6>
+    <div style="background-color: var(--color-neutral-0); padding: 16px; border-radius: 8px; margin-bottom: 30px;">
+      <p style="color: var(--color-text-primary); font: var(--font-body-regular)">This is text-primary on neutral-0
+        background</p>
+      <p style="color: var(--color-text-secondary); font: var(--font-body-regular)">This is text-secondary on neutral-0
+        background</p>
+    </div>
+    <div style="background-color: var(--color-neutral-900); padding: 16px; border-radius: 8px; margin-bottom: 30px;">
+      <p style="color: var(--color-text-inverted); font: var(--font-body-regular)">This is text-inverted on neutral-900
+        background</p>
+    </div>
+
     <h6 style="font: var(--font-heading-3)">Neutral Scale</h6>
     <div class="swatch-grid">
       <div class="color"
@@ -335,8 +342,18 @@
       <div class="color" style="background-color: var(--color-interactive-default);">
         <p>interactive-default</p>
       </div>
-      <div class="color" style="background-color: var(--color-nav-hover);">
+      <div class="color" style="background-color: var(--color-interactive-active);">
         <p>interactive-hover</p>
+      </div>
+    </div>
+
+    <h6 style="font: var(--font-heading-3)">Navigation colors</h6>
+    <div class="swatch-grid">
+      <div class="color" style="background-color: var(--color-nav-default);">
+        <p>nav-default</p>
+      </div>
+      <div class="color" style="background-color: var(--color-nav-hover);">
+        <p>nav-hover</p>
       </div>
     </div>
 
@@ -370,6 +387,27 @@
       </div>
     </div>
 
+    <h6 style="font: var(--font-heading-3)">Border colors</h6>
+    <div class="swatch-grid">
+      <div class="color"
+        style="border: 4px solid var(--border-color-lighter); background-color: var(--color-neutral-0);">
+        <p>border-lighter</p>
+      </div>
+      <div class="color" style="border: 4px solid var(--border-color-light); background-color: var(--color-neutral-0);">
+        <p>border-light</p>
+      </div>
+      <div class="color" style="border: 4px solid var(--border-color); background-color: var(--color-neutral-0);">
+        <p>border</p>
+      </div>
+      <div class="color" style="border: 4px solid var(--border-color-dark); background-color: var(--color-neutral-0);">
+        <p>border-dark</p>
+      </div>
+      <div class="color"
+        style="border: 4px solid var(--border-color-darker); background-color: var(--color-neutral-0);">
+        <p>border-darker</p>
+      </div>
+    </div>
+
     <!-- BLOCK -->
     <div style="height: 60px;"></div>
 
@@ -396,6 +434,12 @@
       </div>
       <div class="space" style="height: var(--space-xxlarge);">
         <p>space-xxl</p>
+      </div>
+      <div class="space" style="height: var(--space-48);">
+        <p>space-48</p>
+      </div>
+      <div class="space" style="height: var(--space-72);">
+        <p>space-72</p>
       </div>
       <div class="space" style="height: var(--space-xxxlarge);">
         <p>space-xxxl</p>

--- a/styleguide.html
+++ b/styleguide.html
@@ -335,7 +335,7 @@
       <div class="color" style="background-color: var(--color-interactive-default);">
         <p>interactive-default</p>
       </div>
-      <div class="color" style="background-color: var(--color-interactive-hover);">
+      <div class="color" style="background-color: var(--color-nav-hover);">
         <p>interactive-hover</p>
       </div>
     </div>

--- a/styleguide.html
+++ b/styleguide.html
@@ -42,7 +42,7 @@
   }
 
   h4 {
-    font: var(--typography-heading-2);
+    font: var(--font-heading-1);
   }
 
   hr {
@@ -78,17 +78,17 @@
   }
 
   .color p {
-    font: var(--typography-caption);
+    font: var(--font-caption);
     position: relative;
     margin-top: 86px;
-    color: var(--color-primary);
+    color: var(--color-brand-primary);
   }
 
   .space p {
-    font: var(--typography-caption);
+    font: var(--font-caption);
     position: relative;
     margin-top: 8px;
-    color: var(--color-primary);
+    color: var(--color-brand-primary);
   }
 
   .table_component {
@@ -97,7 +97,7 @@
   }
 
   .table_component table {
-    border-bottom: 1px solid var(--color-gray-4);
+    border-bottom: 1px solid var(--color-neutral-300);
     height: 100%;
     width: 100%;
     table-layout: auto;
@@ -107,15 +107,15 @@
   }
 
   .table_component th {
-    border-bottom: 1px solid var(--color-gray-4);
-    color: var(--color-primary);
+    border-bottom: 1px solid var(--color-neutral-300);
+    color: var(--color-brand-primary);
     padding: 5px;
   }
 
   .table_component td {
-    font: var(--typography-caption);
-    border-bottom: 1px solid var(--color-gray-4);
-    color: var(--color-primary);
+    font: var(--font-caption);
+    border-bottom: 1px solid var(--color-neutral-300);
+    color: var(--color-brand-primary);
     padding: 12px 0;
   }
 
@@ -132,7 +132,7 @@
 
 <body>
   <!-- ======= Header ======= -->
-  <header id="header" class="header fixed-top" style="background-color: var(--color-background)">
+  <header id="header" class="header fixed-top" style="background-color: var(--color-background-light)">
     <div class="container-fluid container-xl d-flex align-items-center justify-content-between">
       <a href="../index.html" class="logo d-flex align-items-center">
         <!-- <img src="assets/img/logo.png" alt="logo"> -->
@@ -156,7 +156,6 @@
   <main class="container-xl" style="margin-top: 50px;">
 
 
-    <!-- TYPOGRAPHY -->
     <h4>Textstyles</h4>
     <hr>
 
@@ -164,69 +163,75 @@
       <table>
         <tbody>
           <tr>
-            <td>headline <br> 700 3.5em/1.2em</td>
+            <td>display-1 <br> 700 3.5em/1.2em</td>
             <td>
-              <h1 style="font: var(--typography-headline)">Ipsum Dolor Sit Amet</h1>
+              <h1 style="font: var(--font-display-1)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>heading-1 <br> 700 2.5em/1.3em</td>
+            <td>display-2 <br> 700 2.5em/1.3em</td>
             <td>
-              <h1 style="font: var(--typography-heading-1)">Ipsum Dolor Sit Amet</h1>
+              <h1 style="font: var(--font-display-2)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>heading-2 <br> 700 2em/1.3em "Inter"</td>
+            <td>heading-1 <br> 700 2em/1.3em "Bricolage"</td>
             <td>
-              <h1 style="font: var(--typography-heading-2)">Ipsum Dolor Sit Amet</h1>
+              <h1 style="font: var(--font-heading-1)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>heading-3 <br> 700 1.5em/1.5em "Inter"</td>
+            <td>heading-2 <br> 700 1.5em/1.5em "Bricolage"</td>
             <td>
-              <h1 style="font: var(--typography-heading-3)">Ipsum Dolor Sit Amet</h1>
+              <h1 style="font: var(--font-heading-2)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>subhead <br> 300 1.5em/1.5em "Inter"</td>
+            <td>heading-3 <br> 700 1.25em/1.5em "Inter"</td>
             <td>
-              <h1 style="font: var(--typography-subhead)">Ipsum Dolor Sit Amet</h1>
+              <h1 style="font: var(--font-heading-3)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>subtitle <br> 700 1.25em/1.5em "Inter"</td>
+            <td>body-xlarge <br> 300 1.5em/1.5em "Inter"</td>
             <td>
-              <h1 style="font: var(--typography-subtitle)">Ipsum Dolor Sit Amet</h1>
+              <h1 style="font: var(--font-body-regular-large)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>overline <br> 700 1em/1em "Raleway"</td>
+            <td>body-large-strong <br> 700 1em/1.5em "Inter"</td>
             <td>
-              <h1 style="font: var(--typography-overline)">IPSUM DOLOR SIT AMET</h1>
+              <h1 style="font: var(--font-body-bold)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>button <br> 500 1em/1em "Inter"</td>
+            <td>body-large <br> 300 1em/1.5em "Inter"</td>
             <td>
-              <h1 style="font: var(--typography-button)">Ipsum Dolor Sit Amet</h1>
+              <h1 style="font: var(--font-body-regular)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>bodyBold <br> 700 1em/1.5em "Inter"</td>
+            <td>body-default-strong <br> 500 1em/1em "Inter"</td>
             <td>
-              <h1 style="font: var(--typography-bodyBold)">Ipsum Dolor Sit Amet</h1>
+              <h1 style="font: var(--font-label-button)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
           <tr>
-            <td>bodyReg <br> 300 1em/1.5em "Inter"</td>
+            <td>body-default <br> 300 1em/1.5em "Inter"</td>
             <td>
-              <h1 style="font: var(--typography-bodyReg)">Ipsum Dolor Sit Amet</h1>
+              <h1 style="font: var(--font-body-regular)">Ipsum Dolor Sit Amet</h1>
+            </td>
+          </tr>
+          <tr>
+            <td>label <br> 700 1em/1em "Bricolage"</td>
+            <td>
+              <h1 style="font: var(--font-label)">IPSUM DOLOR SIT AMET</h1>
             </td>
           </tr>
           <tr>
             <td>caption <br> 300 0.875em/1.25em "Inter"</td>
             <td>
-              <h1 style="font: var(--typography-caption)">Ipsum Dolor Sit Amet</h1>
+              <h1 style="font: var(--font-caption)">Ipsum Dolor Sit Amet</h1>
             </td>
           </tr>
         </tbody>
@@ -237,98 +242,101 @@
     <div style="height: 60px;"></div>
 
     <!-- COLORS -->
-    <h4 style="font: var(--typography-heading-2)">Colors</h4>
+    <h4 style="font: var(--font-heading-1)">Colors</h4>
     <hr>
 
-    <h6 style="font: var(--typography-subtitle)">Primary colors</h6>
+    <h6 style="font: var(--font-heading-3)">Brand Primary colors</h6>
     <div class="swatch-grid">
-      <div class="color" style="background-color: var(--color-primary-light);">
-        <p>primary-light</p>
+      <div class="color" style="background-color: var(--color-brand-primary-light);">
+        <p>brand-primary-light</p>
       </div>
-      <div class="color" style="background-color: var(--color-primary);">
-        <p>primary</p>
+      <div class="color" style="background-color: var(--color-brand-primary);">
+        <p>brand-primary</p>
       </div>
-      <div class="color" style="background-color: var(--color-primary-dark);">
-        <p>primary-dark</p>
+      <div class="color" style="background-color: var(--color-brand-primary-dark);">
+        <p>brand-primary-dark</p>
       </div>
     </div>
 
-    <h6 style="font: var(--typography-subtitle)">Secondary colors</h6>
+    <h6 style="font: var(--font-heading-3)">Brand Accent colors</h6>
     <div class="swatch-grid">
-      <div class="color" style="background-color: var(--color-secondary-light);">
-        <p>secondary-light</p>
+      <div class="color" style="background-color: var(--color-brand-accent-light);">
+        <p>brand-accent-light</p>
       </div>
-      <div class="color" style="background-color: var(--color-secondary);">
-        <p>secondary</p>
+      <div class="color" style="background-color: var(--color-brand-accent);">
+        <p>brand-accent</p>
       </div>
-      <div class="color" style="background-color: var(--color-secondary-dark);">
-        <p>secondary-dark</p>
+      <div class="color" style="background-color: var(--color-brand-accent-dark);">
+        <p>brand-accent-dark</p>
       </div>
     </div>
 
-    <h6 style="font: var(--typography-subtitle)">Feedback colors</h6>
+    <h6 style="font: var(--font-heading-3)">Status/Semantic colors</h6>
     <div class="swatch-grid">
-      <div class="color" style="background-color: var(--color-information);">
-        <p>information</p>
+      <div class="color" style="background-color: var(--color-status-info);">
+        <p>status-info</p>
       </div>
-      <div class="color" style="background-color: var(--color-critical);">
-        <p>critical</p>
+      <div class="color" style="background-color: var(--color-status-warning);">
+        <p>status-warning</p>
       </div>
-      <div class="color" style="background-color: var(--color-danger);">
-        <p>danger</p>
+      <div class="color" style="background-color: var(--color-status-critical);">
+        <p>status-critical</p>
       </div>
     </div>
 
-    <h6 style="font: var(--typography-subtitle)">Background colors</h6>
+    <h6 style="font: var(--font-heading-3)">Background colors</h6>
     <div class="swatch-grid">
       <div class="color"
-        style="background-color: var(--color-background); border-style: solid; border-width: 1px; border-color: #c7c7c7;">
-        <p>background</p>
+        style="background-color: var(--color-background-light); border-style: solid; border-width: 1px; border-color: #c7c7c7;">
+        <p>background-light</p>
+      </div>
+      <div class="color" style="background-color: var(--color-background-dark);">
+        <p>background-dark</p>
       </div>
     </div>
 
-    <h6 style="font: var(--typography-subtitle)">Greyscale colors</h6>
+    <h6 style="font: var(--font-heading-3)">Neutral Scale</h6>
     <div class="swatch-grid">
       <div class="color"
-        style="background-color: var(--color-gray-1); border-style: solid; border-width: 1px; border-color: #c7c7c7;">
-        <p>gray-1</p>
+        style="background-color: var(--color-neutral-50); border-style: solid; border-width: 1px; border-color: #c7c7c7;">
+        <p>neutral-50</p>
       </div>
-      <div class="color" style="background-color: var(--color-gray-2);">
-        <p>gray-2</p>
+      <div class="color" style="background-color: var(--color-neutral-100);">
+        <p>neutral-100</p>
       </div>
-      <div class="color" style="background-color: var(--color-gray-3);">
-        <p>gray-3</p>
+      <div class="color" style="background-color: var(--color-neutral-200);">
+        <p>neutral-200</p>
       </div>
-      <div class="color" style="background-color: var(--color-gray-4);">
-        <p>gray-4</p>
+      <div class="color" style="background-color: var(--color-neutral-300);">
+        <p>neutral-300</p>
       </div>
-      <div class="color" style="background-color: var(--color-gray-5);">
-        <p>gray-5</p>
+      <div class="color" style="background-color: var(--color-neutral-400);">
+        <p>neutral-400</p>
       </div>
-      <div class="color" style="background-color: var(--color-gray-6);">
-        <p>gray-6</p>
+      <div class="color" style="background-color: var(--color-neutral-500);">
+        <p>neutral-500</p>
       </div>
-      <div class="color" style="background-color: var(--color-gray-7);">
-        <p>gray-7</p>
+      <div class="color" style="background-color: var(--color-neutral-600);">
+        <p>neutral-600</p>
       </div>
-      <div class="color" style="background-color: var(--color-gray-8);">
-        <p>gray-8</p>
+      <div class="color" style="background-color: var(--color-neutral-700);">
+        <p>neutral-700</p>
       </div>
-      <div class="color" style="background-color: var(--color-gray-9);">
-        <p>gray-9</p>
+      <div class="color" style="background-color: var(--color-neutral-800);">
+        <p>neutral-800</p>
       </div>
-      <div class="color" style="background-color: var(--color-gray-10);">
-        <p>gray-10</p>
+      <div class="color" style="background-color: var(--color-neutral-900);">
+        <p>neutral-900</p>
       </div>
     </div>
 
-    <h6 style="font: var(--typography-subtitle)">Navigation colors</h6>
+    <h6 style="font: var(--font-heading-3)">Interactive colors</h6>
     <div class="swatch-grid">
-      <div class="color" style="background-color: var(--color-nav-default);">
-        <p>nav-default</p>
+      <div class="color" style="background-color: var(--color-interactive-default);">
+        <p>interactive-default</p>
       </div>
-      <div class="color" style="background-color: var(--color-nav-hover);">
-        <p>nav-hover</p>
+      <div class="color" style="background-color: var(--color-interactive-hover);">
+        <p>interactive-hover</p>
       </div>
     </div>
 
@@ -341,23 +349,23 @@
 
     <div class="swatch-grid">
       <div class="color"
-        style="border-radius: var(--border-radius-small); border-style: solid; border-width: 1px; border-color: var(--color-gray-5);">
+        style="border-radius: var(--border-radius-small); border-style: solid; border-width: 1px; border-color: var(--color-neutral-400);">
         <p>small</p>
       </div>
       <div class="color"
-        style="border-radius: var(--border-radius-medium); border-style: solid; border-width: 1px; border-color: var(--color-gray-5);">
+        style="border-radius: var(--border-radius-medium); border-style: solid; border-width: 1px; border-color: var(--color-neutral-400);">
         <p>medium</p>
       </div>
       <div class="color"
-        style="border-radius: var(--border-radius-large); border-style: solid; border-width: 1px; border-color: var(--color-gray-5);">
+        style="border-radius: var(--border-radius-large); border-style: solid; border-width: 1px; border-color: var(--color-neutral-400);">
         <p>large</p>
       </div>
       <div class="color"
-        style="border-radius: var(--border-radius-xlarge); border-style: solid; border-width: 1px; border-color: var(--color-gray-5);">
+        style="border-radius: var(--border-radius-xlarge); border-style: solid; border-width: 1px; border-color: var(--color-neutral-400);">
         <p>xlarge</p>
       </div>
       <div class="color"
-        style="border-radius: var(--border-radius-circle); border-style: solid; border-width: 1px; border-color: var(--color-gray-5);">
+        style="border-radius: var(--border-radius-circle); border-style: solid; border-width: 1px; border-color: var(--color-neutral-400);">
         <p>circle</p>
       </div>
     </div>
@@ -369,7 +377,7 @@
     <h4>Spacing</h4>
     <hr>
 
-    <h6 style="font: var(--typography-subtitle)">Core spacing</h6>
+    <h6 style="font: var(--font-heading-3)">Core spacing</h6>
     <div class="swatch-grid">
       <div class="space" style="height: var(--space-xsmall);">
         <p>space-xs</p>
@@ -394,7 +402,7 @@
       </div>
     </div>
 
-    <h6 style="font: var(--typography-subtitle)">Semantic spacing</h6>
+    <h6 style="font: var(--font-heading-3)">Semantic spacing</h6>
     <div class="swatch-grid">
       <div class="space" style="height: var(--space-section);">
         <p>space-section</p>

--- a/tokens.css
+++ b/tokens.css
@@ -126,8 +126,9 @@
 
     /* Interactive State Colors */
     --color-interactive-default:  #3F75FF;
-    --color-interactive-hover:    #C2D4FF;
     --color-interactive-active:   #2753C1;
+    --color-nav-default:    #E8ECF5;
+    --color-nav-hover:    #C2D4FF;
 
     /* Status/Semantic Colors */
     --color-status-warning:       #FFA500;
@@ -159,9 +160,6 @@
     --color-critical:             var(--color-status-warning);
     --color-information:          var(--color-status-info);
     --color-danger:               var(--color-status-critical);
-
-    --color-nav-default:          var(--color-interactive-default);
-    --color-nav-hover:            var(--color-interactive-hover);
 
     /* Border
     ================================================================= */
@@ -217,8 +215,9 @@
     --color-neutral-900:          #F5F7FC;
 
     --color-interactive-default:  #0E3352;
-    --color-interactive-hover:    #164A6E;
     --color-interactive-active:   #3F75FF;
+    --color-nav-default:    #28384F;
+    --color-nav-hover:    #164A6E;
 
     --color-status-warning:       #FFA500;
     --color-status-info:          #0E3352;
@@ -249,7 +248,4 @@
     --color-critical:             var(--color-status-warning);
     --color-information:          var(--color-status-info);
     --color-danger:               var(--color-status-critical);
-
-    --color-nav-default:          var(--color-interactive-default);
-    --color-nav-hover:            var(--color-interactive-hover);
 }

--- a/tokens.css
+++ b/tokens.css
@@ -7,8 +7,8 @@
     /* Typography
     ================================================================= */
     /* Fonts family*/
-    --font-family-primary: "Inter", sans-serif;
-    --font-family-secondary: "Bricolage Grotesque", sans-serif;
+    --font-family-body:     "Inter", sans-serif;
+    --font-family-display:  "Bricolage Grotesque", sans-serif;
     /* Font sizes - 4x4 grid */
     --font-base-unit:   var(--base-unit);
     --font-size-12:     calc(var(--font-base-unit) * 3);
@@ -23,18 +23,44 @@
     --line-height-small:   calc(var(--line-height-base-unit) * 1.1);
     --line-height-medium:  calc(var(--line-height-base-unit) * 1.3);
     --line-height-large:   calc(var(--line-height-base-unit) * 1.5);
-    /* Global typography styles*/
-    --typography-headline:      700 3.5em/1.2em var(--font-family-secondary);   /* 56px Bricolage*/
-    --typography-heading-1:     700 2.5em/1.3em var(--font-family-secondary);   /* 40px Bricolage*/
-    --typography-heading-2:     700 2em/1.3em var(--font-family-secondary);     /* 32px*/
-    --typography-heading-3:     700 1.5em/1.5em var(--font-family-secondary);   /* 24px*/
-    --typography-subhead:       300 1.5em/1.5em var(--font-family-primary);     /* 24px*/
-    --typography-subtitle:      700 1.25em/1.5em var(--font-family-primary);    /* 20px*/
-    --typography-overline:      700 1em/1em var(--font-family-secondary);       /* 16px Bricolage*/
-    --typography-button:        500 1em/1em var(--font-family-primary);         /* 16px*/
-    --typography-bodyBold:      700 1em/1.5em var(--font-family-primary);       /* 16px*/
-    --typography-bodyReg:       300 1em/1.5em var(--font-family-primary);       /* 16px*/
-    --typography-caption:       300 0.875em/1.25em var(--font-family-primary);  /* 14px*/
+    
+    /* Typography Scales - Display */
+    --font-display-1:       700 3.5em/1.2em var(--font-family-display);   /* 56px Bricolage - hero headlines */
+    --font-display-2:       700 2.5em/1.3em var(--font-family-display);   /* 40px Bricolage - page titles */
+    
+    /* Typography Scales - Headings */
+    --font-heading-1:       700 2em/1.3em var(--font-family-display);     /* 32px */
+    --font-heading-2:       700 1.5em/1.5em var(--font-family-display);   /* 24px */
+    --font-heading-3:       700 1.25em/1.5em var(--font-family-display);     /* 20px - section headings */
+    
+    /* Typography Scales - Body */
+    --font-body-regular-large:         300 1.5em/1.5em var(--font-family-body);      /* 24px regular - subhead */
+    --font-body-bold:           700 1em/1.5em var(--font-family-body);        /* 16px bold */
+    --font-body-regular:        300 1em/1.5em var(--font-family-body);        /* 16px regular */
+    
+    /* Typography Scales - Label */
+    --font-label:           700 1em/1em var(--font-family-display);       /* 16px label/overline */
+    --font-label-button:    500 1em/1em var(--font-family-body);          /* 16px medium - buttons */
+    
+    /* Typography Scales - Caption */
+    --font-caption:         300 0.875em/1.25em var(--font-family-body);  /* 14px small text */
+    
+    /* Legacy typography aliases for backward compatibility */
+    --typography-headline:      var(--font-display-1);
+    --typography-heading-1:     var(--font-display-2);
+    --typography-heading-2:     var(--font-heading-1);
+    --typography-heading-3:     var(--font-heading-2);
+    --typography-subhead:       var(--font-body-regular-large);
+    --typography-subtitle:      var(--font-heading-3);
+    --typography-overline:      var(--font-label);
+    --typography-button:        var(--font-label-button);
+    --typography-bodyBold:      var(--font-body-bold);
+    --typography-bodyReg:       var(--font-body-regular);
+    --typography-caption:       var(--font-caption);
+    
+    /* Legacy font family aliases */
+    --font-family-primary:      var(--font-family-body);
+    --font-family-secondary:    var(--font-family-display);
 
     /* Space
      ================================================================= */
@@ -67,33 +93,75 @@
 
     /* Color
     ================================================================= */
-    --color-primary-light:  #253C6E;
-    --color-primary:        #0C1527;
-    --color-primary-dark:   #060C18;
+    /* Brand Colors */
+    --color-brand-primary-light:  #253C6E;
+    --color-brand-primary:        #0C1527;
+    --color-brand-primary-dark:   #060C18;
 
-    --color-secondary-light:#799FFF;
-    --color-secondary:      #3F75FF;
-    --color-secondary-dark: #2753C1;
+    --color-brand-accent-light:   #799FFF;
+    --color-brand-accent:         #3F75FF;
+    --color-brand-accent-dark:    #2753C1;
 
-    --color-background:     #F5F7FC;
+    /* Text Colors */
+    --color-text-primary:         #0C1527;
+    --color-text-secondary:       #3E4E65;
+    --color-text-inverted:        #FFFFFF;
 
-    --color-gray-1:         #F5F7FC;
-    --color-gray-2:         #E8ECF5;
-    --color-gray-3:         #D4DAE8;
-    --color-gray-4:         #B0BBCE;
-    --color-gray-5:         #8C9AB2;
-    --color-gray-6:         #6E7D96;
-    --color-gray-7:         #55637A;
-    --color-gray-8:         #3E4E65;
-    --color-gray-9:         #28384F;
-    --color-gray-10:        #141E2E;
+    /* Background Colors */
+    --color-background-light:     #F5F7FC;
+    --color-background-dark:      #141E2E;
 
-    --color-critical:       #FFA500;
-    --color-information:    #DAE8F1;
-    --color-danger:         #FF4500;
+    /* Neutral Scale (Gray) */
+    --color-neutral-0:            #FFFFFF;
+    --color-neutral-50:           #F5F7FC;
+    --color-neutral-100:          #E8ECF5;
+    --color-neutral-200:          #D4DAE8;
+    --color-neutral-300:          #B0BBCE;
+    --color-neutral-400:          #8C9AB2;
+    --color-neutral-500:          #6E7D96;
+    --color-neutral-600:          #55637A;
+    --color-neutral-700:          #3E4E65;
+    --color-neutral-800:          #28384F;
+    --color-neutral-900:          #141E2E;
 
-    --color-nav-default:    #E8ECF5;
-    --color-nav-hover:      #C2D4FF;
+    /* Interactive State Colors */
+    --color-interactive-default:  #3F75FF;
+    --color-interactive-hover:    #C2D4FF;
+    --color-interactive-active:   #2753C1;
+
+    /* Status/Semantic Colors */
+    --color-status-warning:       #FFA500;
+    --color-status-info:          #DAE8F1;
+    --color-status-critical:      #FF4500;
+
+    /* Legacy color aliases for backward compatibility */
+    --color-primary-light:        var(--color-brand-primary-light);
+    --color-primary:              var(--color-brand-primary);
+    --color-primary-dark:         var(--color-brand-primary-dark);
+
+    --color-secondary-light:      var(--color-brand-accent-light);
+    --color-secondary:            var(--color-brand-accent);
+    --color-secondary-dark:       var(--color-brand-accent-dark);
+
+    --color-background:           var(--color-background-light);
+
+    --color-gray-1:               var(--color-neutral-50);
+    --color-gray-2:               var(--color-neutral-100);
+    --color-gray-3:               var(--color-neutral-200);
+    --color-gray-4:               var(--color-neutral-300);
+    --color-gray-5:               var(--color-neutral-400);
+    --color-gray-6:               var(--color-neutral-500);
+    --color-gray-7:               var(--color-neutral-600);
+    --color-gray-8:               var(--color-neutral-700);
+    --color-gray-9:               var(--color-neutral-800);
+    --color-gray-10:              var(--color-neutral-900);
+
+    --color-critical:             var(--color-status-warning);
+    --color-information:          var(--color-status-info);
+    --color-danger:               var(--color-status-critical);
+
+    --color-nav-default:          var(--color-interactive-default);
+    --color-nav-hover:            var(--color-interactive-hover);
 
     /* Border
     ================================================================= */
@@ -121,31 +189,67 @@
 }
 
 .dark {
-    --color-primary-light:  #FFFFFF;
-    --color-primary:        #FFFFFF;
-    --color-primary-dark:   #80A4EC;
+    --color-brand-primary-light:  #FFFFFF;
+    --color-brand-primary:        #FFFFFF;
+    --color-brand-primary-dark:   #80A4EC;
 
-    --color-secondary-light:#2753C1;
-    --color-secondary:      #3F75FF;
-    --color-secondary-dark: #799FFF;
+    --color-brand-accent-light:   #2753C1;
+    --color-brand-accent:         #3F75FF;
+    --color-brand-accent-dark:    #799FFF;
 
-    --color-background:     #141E2E;
+    --color-text-primary:         #FFFFFF;
+    --color-text-secondary:       #D4DAE8;
+    --color-text-inverted:        #0C1527;
 
-    --color-gray-1:         #141E2E;
-    --color-gray-2:         #28384F;
-    --color-gray-3:         #3E4E65;
-    --color-gray-4:         #55637A;
-    --color-gray-5:         #6E7D96;
-    --color-gray-6:         #8C9AB2;
-    --color-gray-7:         #B0BBCE;
-    --color-gray-8:         #D4DAE8;
-    --color-gray-9:         #E8ECF5;
-    --color-gray-10:        #F5F7FC;
+    --color-background-light:     #141E2E;
+    --color-background-dark:      #141E2E;
 
-    --color-critical:       #FFA500;
-    --color-information:    #0E3352;
-    --color-danger:         #B13508;
+    --color-neutral-0:            #141E2E;
+    --color-neutral-50:           #141E2E;
+    --color-neutral-100:          #28384F;
+    --color-neutral-200:          #3E4E65;
+    --color-neutral-300:          #55637A;
+    --color-neutral-400:          #6E7D96;
+    --color-neutral-500:          #8C9AB2;
+    --color-neutral-600:          #B0BBCE;
+    --color-neutral-700:          #D4DAE8;
+    --color-neutral-800:          #E8ECF5;
+    --color-neutral-900:          #F5F7FC;
 
-    --color-nav-default:    #0E3352;
-    --color-nav-hover:      #164A6E;
+    --color-interactive-default:  #0E3352;
+    --color-interactive-hover:    #164A6E;
+    --color-interactive-active:   #3F75FF;
+
+    --color-status-warning:       #FFA500;
+    --color-status-info:          #0E3352;
+    --color-status-critical:      #B13508;
+
+    /* Legacy color aliases */
+    --color-primary-light:        var(--color-brand-primary-light);
+    --color-primary:              var(--color-brand-primary);
+    --color-primary-dark:         var(--color-brand-primary-dark);
+
+    --color-secondary-light:      var(--color-brand-accent-light);
+    --color-secondary:            var(--color-brand-accent);
+    --color-secondary-dark:       var(--color-brand-accent-dark);
+
+    --color-background:           var(--color-background-light);
+
+    --color-gray-1:               var(--color-neutral-50);
+    --color-gray-2:               var(--color-neutral-100);
+    --color-gray-3:               var(--color-neutral-200);
+    --color-gray-4:               var(--color-neutral-300);
+    --color-gray-5:               var(--color-neutral-400);
+    --color-gray-6:               var(--color-neutral-500);
+    --color-gray-7:               var(--color-neutral-600);
+    --color-gray-8:               var(--color-neutral-700);
+    --color-gray-9:               var(--color-neutral-800);
+    --color-gray-10:              var(--color-neutral-900);
+
+    --color-critical:             var(--color-status-warning);
+    --color-information:          var(--color-status-info);
+    --color-danger:               var(--color-status-critical);
+
+    --color-nav-default:          var(--color-interactive-default);
+    --color-nav-hover:            var(--color-interactive-hover);
 }

--- a/whitelabel.html
+++ b/whitelabel.html
@@ -471,7 +471,7 @@
   <footer class="footer">
     <div class="copyright">
       <p>Created with <a href="https://bootstrapmade.com/" target="_blank" rel="noopener noreferrer">Bootstrap</a> |
-        2025</p>
+        2026</p>
       <div class="footer-social">
         <ul>
           <li>


### PR DESCRIPTION
Rename and standardize typography and color design tokens, add new token scales (display/headings/body/label/caption) and neutral/brand/interactive/status color sets in tokens.css, and provide legacy aliases for backward compatibility. Update custom.css, styleguide.html and designsystem.html to use the new variables (font-, color- and semantic- prefixed names), adjust text and color usage, and tweak a container class removal in designsystem.html. These changes consolidate token naming, improve theme/dark-mode support and keep existing styles working via legacy aliases.

## Issue description

## Pull request checklist
- [ ] I've updated the localization
- [x] I've updated the [CHANGELOG](https://github.com/mathnauleau/mathnauleau.github.io/blob/main/CHANGELOG.md)